### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # calculator
+[![smithery badge](https://smithery.ai/badge/@QuantGeekDev/mcp-add-sse)](https://smithery.ai/server/@QuantGeekDev/mcp-add-sse)
 
 A Model Context Protocol (MCP) server built with mcp-framework.
 
@@ -100,6 +101,14 @@ After publishing, users can add it to their claude desktop client (read below) o
 ```
 
 ## Using with Claude Desktop
+
+### Installing via Smithery
+
+To install Calculator for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@QuantGeekDev/mcp-add-sse):
+
+```bash
+npx -y @smithery/cli install @QuantGeekDev/mcp-add-sse --client claude
+```
 
 ### Local Development
 

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,20 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - jwtSecret
+    properties:
+      jwtSecret:
+        type: string
+        description: Secret key for JWT authentication.
+      port:
+        type: number
+        description: Port number for the MCP server.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({command:'node', args:['dist/index.js'], env:{JWT_SECRET:config.jwtSecret, PORT:config.port ? config.port.toString() : '1337'}})


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over WebSockets so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@QuantGeekDev/mcp-add-sse?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂